### PR TITLE
updated linter to access files in packages

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -16,4 +16,4 @@ jobs:
         run: python -m pip install --upgrade pip pycodestyle
 
       - name: Check Style
-        run: pycodestyle color/imagga.py images/unsplash.py tests/unittests.py
+        run: pycodestyle --first color/imagga.py images/unsplash.py tests/*.py

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -16,4 +16,4 @@ jobs:
         run: python -m pip install --upgrade pip pycodestyle
 
       - name: Check Style
-        run: pycodestyle --first color/imagga.py images/unsplash.py tests/*.py
+        run: pycodestyle color/imagga.py images/unsplash.py tests/*.py

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -16,4 +16,4 @@ jobs:
         run: python -m pip install --upgrade pip pycodestyle
 
       - name: Check Style
-        run: pycodestyle --first *.py
+        run: pycodestyle color/imagga.py images/unsplash.py tests/unittests.py


### PR DESCRIPTION
Allows checkstyle to check current test file (will have to update with any new additions), the imagga.py file, and the unsplash.py file